### PR TITLE
Log job child process exit status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ package-lock.json
 
 # generated config files by tests
 **/generated-gobblin-cluster.conf
+
+temp/

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleHelixTask.java
@@ -61,8 +61,11 @@ public class SingleHelixTask implements Task {
               this.jobName, this.jobId));
       int exitCode = this.taskProcess.waitFor();
       if (exitCode == 0) {
+        logger.info("Task process finished. job name: {}. job id: {}", this.jobName, this.jobId);
         return new TaskResult(TaskResult.Status.COMPLETED, "");
       } else {
+        logger.warn("Task process failed with exitcode ({}). job name: {}. job id: {}", exitCode,
+            this.jobName, this.jobId);
         return new TaskResult(TaskResult.Status.FAILED, "Exit code: " + exitCode);
       }
     } catch (final Throwable t) {

--- a/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
+++ b/gobblin-cluster/src/main/java/org/apache/gobblin/cluster/SingleTaskLauncher.java
@@ -55,7 +55,9 @@ class SingleTaskLauncher {
     logger.info("Launching a task process.");
 
     // The -cp parameter list can be very long.
-    logger.debug("cmd: " + command);
+    final String completeCmdLine = String.join(" ", command);
+    logger.debug("cmd line:\n{}", completeCmdLine);
+
     final Process taskProcess = this.processBuilder.start(command);
 
     return taskProcess;


### PR DESCRIPTION
Also

log the cmd line in one line for the child process.

ignore temp directory under the project root.

Testing:

Manually checked the log messages in the log of an integration test.

Closes #2252 from HappyRay/log-child-job-process-
exit-status

Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-XXX] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-XXX


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

